### PR TITLE
Ensure the First Run Onboarding is only shown once.

### DIFF
--- a/DuckDuckGo/DDGFirstRunViewController.m
+++ b/DuckDuckGo/DDGFirstRunViewController.m
@@ -24,8 +24,11 @@ NSString * const DDGUserDefaultHasShownFirstRunKey = @"DDGUserDefaultHasShownFir
 }
 
 - (void)viewDidAppear:(BOOL)animated {
-    [super viewDidAppear:animated];    
+    [super viewDidAppear:animated];
+    
+    // Ensure the value is serialized immediately.
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:DDGUserDefaultHasShownFirstRunKey];
+    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 - (IBAction)dismiss:(id)sender {


### PR DESCRIPTION
Synchronized HasShowFirstRun bool immediately after setting in FirstRunViewController. If the user killed the application prior to NSUserDefaults being synchronized, it was possible for this bool status to be lost and the user would be presented with the onboarding twice.
