### PR TITLE
Reduced warnings down to two.

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -299,7 +299,6 @@
 		7B2BDF9D18E966BB003B8078 /* DDGHorizontalPanGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B2BDF9C18E966BB003B8078 /* DDGHorizontalPanGestureRecognizer.m */; };
 		7B2BDFA018E997C8003B8078 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B2BDF9F18E997C8003B8078 /* CoreText.framework */; };
 		7B2BDFA618E997ED003B8078 /* HockeySDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B2BDFA218E997ED003B8078 /* HockeySDK.framework */; };
-		7B2BDFA718E997ED003B8078 /* HockeySDK.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 7B2BDFA418E997ED003B8078 /* HockeySDK.xcconfig */; };
 		7B2BDFA818E997ED003B8078 /* HockeySDKResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 7B2BDFA518E997ED003B8078 /* HockeySDKResources.bundle */; };
 		7B3BB7F7192E0F0A00E94055 /* DDGWebView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B3BB7F6192E0F0A00E94055 /* DDGWebView.m */; };
 		7B3BB7F9192E350900E94055 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B3BB7F8192E350900E94055 /* AssetsLibrary.framework */; };
@@ -1684,7 +1683,7 @@
 		83F3224F149290EF00A61BC5 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0460;
+				LastUpgradeCheck = 0510;
 			};
 			buildConfigurationList = 83F32252149290EF00A61BC5 /* Build configuration list for PBXProject "DuckDuckGo" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -1832,7 +1831,6 @@
 				5B2FCAD916F32BE10045A5FE /* Safari.png in Resources */,
 				5B2FCADA16F32BE10045A5FE /* Safari@2x.png in Resources */,
 				5B2FCADB16F32BE10045A5FE /* Safari@2x~ipad.png in Resources */,
-				7B2BDFA718E997ED003B8078 /* HockeySDK.xcconfig in Resources */,
 				5B2FCADC16F32BE10045A5FE /* Safari~ipad.png in Resources */,
 				5B07085716FC74800058718F /* ui-activity_readability-off.png in Resources */,
 				5B07085816FC74800058718F /* ui-activity_readability-off@2x.png in Resources */,
@@ -2152,8 +2150,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -2161,9 +2160,12 @@
 				COPY_PHASE_STRIP = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
@@ -2234,8 +2236,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -2250,11 +2253,15 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				ONLY_ACTIVE_ARCH = YES;
 				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = YES;
@@ -2266,8 +2273,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -2275,9 +2283,12 @@
 				COPY_PHASE_STRIP = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";

--- a/DuckDuckGo/DDGAutocompleteTableView.m
+++ b/DuckDuckGo/DDGAutocompleteTableView.m
@@ -7,6 +7,7 @@
 //
 
 #import "DDGAutocompleteTableView.h"
+#import "DDGAutocompleteViewController.h"
 
 @implementation DDGAutocompleteTableView
 

--- a/DuckDuckGo/DDGAutocompleteViewController.h
+++ b/DuckDuckGo/DDGAutocompleteViewController.h
@@ -10,10 +10,10 @@
 #import "DDGHistoryProvider.h"
 #import "DDGSearchSuggestionsProvider.h"
 
-@interface DDGAutocompleteViewController : UITableViewController {
-}
+@interface DDGAutocompleteViewController : UITableViewController
 @property (nonatomic, strong) DDGHistoryProvider *historyProvider;
 
 -(void)searchFieldDidChange:(id)sender;
+-(void)tableViewBackgroundTouched;
 
 @end

--- a/DuckDuckGo/DDGChooseRegionViewController.m
+++ b/DuckDuckGo/DDGChooseRegionViewController.m
@@ -32,7 +32,7 @@
     // we need to offset the triforce image by 1px down to compensate for the shadow in the image
     float topInset = 1.0f;
     button.imageEdgeInsets = UIEdgeInsetsMake(topInset, 0.0f, -topInset, 0.0f);
-    [button addTarget:self action:@selector(saveAndExit) forControlEvents:UIControlEventTouchUpInside];
+    [button addTarget:self action:NSSelectorFromString(@"saveAndExit") forControlEvents:UIControlEventTouchUpInside];
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:button];
 	
 	// force 1st time through for iOS < 6.0

--- a/DuckDuckGo/DDGPlusButton.m
+++ b/DuckDuckGo/DDGPlusButton.m
@@ -8,6 +8,10 @@
 
 #import "DDGPlusButton.h"
 
+@interface NSObject ()
+- (IBAction)plus:(id)sender;
+@end
+
 @implementation DDGPlusButton
 
 + (id)plusButtonWithImageName:(NSString *)imageName BackgroundImageNamed:(NSString *)backgroundImageName {

--- a/DuckDuckGo/DDGSlidingViewController.m
+++ b/DuckDuckGo/DDGSlidingViewController.m
@@ -39,7 +39,7 @@
     [super viewDidLoad];
     
     self.oldPanGesture = [super panGesture];    
-    self.panGesture = [[DDGHorizontalPanGestureRecognizer alloc] initWithTarget:self action:@selector(updateTopViewHorizontalCenterWithRecognizer:)];
+    self.panGesture = [[DDGHorizontalPanGestureRecognizer alloc] initWithTarget:self action:NSSelectorFromString(@"updateTopViewHorizontalCenterWithRecognizer:")];
 }
 
 - (void)anchorTopViewTo:(ECSide)side animations:(void (^)())animations onComplete:(void (^)())complete {

--- a/DuckDuckGo/DDGStoriesViewController.h
+++ b/DuckDuckGo/DDGStoriesViewController.h
@@ -22,4 +22,7 @@
 @property (nonatomic, strong) UIImage *searchControllerBackButtonIconDDG;
 
 - (id)initWithSearchHandler:(id <DDGSearchHandler>)searchHandler managedObjectContext:(NSManagedObjectContext *)managedObjectContext;
+
+- (IBAction)filter:(id)sender;
+
 @end

--- a/DuckDuckGo/DDGStoryCell.m
+++ b/DuckDuckGo/DDGStoryCell.m
@@ -8,6 +8,7 @@
 
 #import "DDGFaviconButton.h"
 #import "DDGStoryCell.h"
+#import "DDGStoriesViewController.h"
 
 NSString *const DDGStoryCellIdentifier = @"StoryCell";
 


### PR DESCRIPTION
I wasn't able to fix them all. There's one left in AFNetworking, and another referencing `currentPopoverController`, then this project will be warning free :+1: 
