### PR TITLE
GH ISSUE #53 - "Change Sources" show duplicates on initial launch of iOS DuckDuckGo app

### DIFF
--- a/DuckDuckGo/DDGStoryFetcher.m
+++ b/DuckDuckGo/DDGStoryFetcher.m
@@ -85,6 +85,11 @@ NSString * const DDGStoryFetcherSourcesLastUpdatedKey = @"sourcesUpdated";
                         feed = [results objectAtIndex:0];
                     } else {
                         feed = [DDGStoryFeed insertInManagedObjectContext:context];
+                        NSError *error = nil;
+                        BOOL success = [context obtainPermanentIDsForObjects:@[feed] error:&error];
+                        if (!success) {
+                            NSLog(@"error: %@", error);
+                        }
                         feed.feedState = DDGStoryFeedStateDefault;
                     }
                     


### PR DESCRIPTION
This seems to stem from not having permanent id's for our `DDGStoryFeed`
entity while saving them after fetching their display images. When
working wtih temp objectID's, `NSFetchedResultsController` (in
`DDGChooseSourcesViewController`), seems to be generating inserts into
the tableview, for each feed after image has been updated.

With this patch, we force CoreData to generate a permanent id for each
`DDGStoryFeed` entity when we create it. `NSFetchedResultsController` then
correctly generates updates for the associated tableview rows, when
the entity is saved (with `imageDownloaded` flag on).
