### PR TITLE
Submodules url https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "AFNetworking"]
 	path = AFNetworking
-	url = git://github.com/AFNetworking/AFNetworking.git
+	url = https://github.com/AFNetworking/AFNetworking.git
 [submodule "Submodules/AFNetworking"]
 	path = Submodules/AFNetworking
-	url = git://github.com/AFNetworking/AFNetworking.git
+	url = https://github.com/AFNetworking/AFNetworking.git
 [submodule "Submodules/SDURLCache"]
 	path = Submodules/SDURLCache
-	url = git://github.com/rs/SDURLCache.git
+	url = https://github.com/rs/SDURLCache.git
 [submodule "Submodules/IGFormViewController"]
 	path = Submodules/IGFormViewController
-	url = git@github.com:TheInfiniteKind/IGFormViewController.git
+	url = https://github.com/TheInfiniteKind/IGFormViewController.git
 [submodule "Submodules/TUSafariActivity"]
 	path = Submodules/TUSafariActivity
-	url = git://github.com/davbeck/TUSafariActivity.git
+	url = https://github.com/davbeck/TUSafariActivity.git
 [submodule "Submodules/MGSplitViewController"]
 	path = Submodules/MGSplitViewController
 	url = https://github.com/TheInfiniteKind/MGSplitViewController.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,13 @@ The App Store version of the app uses a font, *ProximaNova*, whose license prohi
 
 After copying the font to the Xcode project, you'll need to change any references to it, including source code and xibs (use the Find navigator to help here!), and remove the 4 *ProximaNova* references in the "Copy Bundle Resources" section of the project's Build Phases (there are a lot of resouces&mdash;filter on `ProximaNova` to make this faster).
 
+### Submodules
+This repository has submodules, please init them before building by running this command on terminal:
+
+```console
+git submodule update --init --recursive
+```
+
 ## Changes
 * **Bugs** fork the repository on GitHub and create a topic branch from **master** with your GitHub username in the branch name like:
   `git checkout -b nilnilnil/segfault-stories-swipe origin/master`


### PR DESCRIPTION
I always get `Permission denied (publickey)` error when init `Submodules/IGFormViewController` submodule. And since [github recommend https url](https://help.github.com/articles/which-remote-url-should-i-use/#cloning-with-https-urls-recommended) over ssh url , I decided to update all submodule url to `https://` URLs. I also add an instruction of how to init submodule on CONTRIBUTING.md file.
