### PR TITLE
Header collapsing, universal linking, and feedback-email fix

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -1891,6 +1891,14 @@
 					};
 					83F32257149290EF00A61BC5 = {
 						DevelopmentTeam = HKE973VLUW;
+						SystemCapabilities = {
+							com.apple.Keychain = {
+								enabled = 0;
+							};
+							com.apple.SafariKeychain = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};
@@ -2853,7 +2861,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
-				PROVISIONING_PROFILE = "$(PROFILE_UDID)";
 				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2868,8 +2875,8 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_ENTITLEMENTS = DuckDuckGo/DuckDuckGo.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG = 1;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -2885,7 +2892,6 @@
 					"-all_load",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SCAN_ALL_SOURCE_FILES_FOR_INCLUDES = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "DuckDuckGo/DuckDuckGo-Bridging-Header.h";
@@ -2950,7 +2956,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				ONLY_ACTIVE_ARCH = YES;
-				PROVISIONING_PROFILE = "$(PROFILE_UDID)";
 				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -2985,7 +2990,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
-				PROVISIONING_PROFILE = "$(PROFILE_UDID)";
 				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3000,8 +3004,8 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_ENTITLEMENTS = DuckDuckGo/DuckDuckGo.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG = 1;
 				"DEBUG[arch=*]" = 1;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -3018,7 +3022,6 @@
 					"-all_load",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SCAN_ALL_SOURCE_FILES_FOR_INCLUDES = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "DuckDuckGo/DuckDuckGo-Bridging-Header.h";
@@ -3037,8 +3040,8 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_ENTITLEMENTS = DuckDuckGo/DuckDuckGo.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG = 0;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -3054,7 +3057,6 @@
 					"-all_load",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SCAN_ALL_SOURCE_FILES_FOR_INCLUDES = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "DuckDuckGo/DuckDuckGo-Bridging-Header.h";
@@ -3091,7 +3093,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
-				PROVISIONING_PROFILE = "$(PROFILE_UDID)";
 				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3106,8 +3107,8 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGN_ENTITLEMENTS = DuckDuckGo/DuckDuckGo.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG = 1;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -3123,7 +3124,6 @@
 					"-all_load",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SCAN_ALL_SOURCE_FILES_FOR_INCLUDES = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "DuckDuckGo/DuckDuckGo-Bridging-Header.h";

--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		48449FEF1C603D160042CFBD /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48449FEE1C603D160042CFBD /* WebKit.framework */; };
+		4849B95F1CC8774500E27C5C /* DDGStoriesLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 4849B95E1CC8774500E27C5C /* DDGStoriesLayout.m */; };
 		484A10C21C4C47AD00948ED4 /* DDGStoryMenu.m in Sources */ = {isa = PBXBuildFile; fileRef = 484A10C11C4C47AD00948ED4 /* DDGStoryMenu.m */; };
 		48690A001C489CB900083D49 /* DDGTraitHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 486909FF1C489CB900083D49 /* DDGTraitHelper.m */; };
 		486E7C7F1C5E887A00287A35 /* DDGConstraintHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 486E7C7E1C5E887A00287A35 /* DDGConstraintHelper.m */; };
@@ -346,6 +347,8 @@
 
 /* Begin PBXFileReference section */
 		48449FEE1C603D160042CFBD /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		4849B95D1CC8774500E27C5C /* DDGStoriesLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDGStoriesLayout.h; sourceTree = "<group>"; };
+		4849B95E1CC8774500E27C5C /* DDGStoriesLayout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDGStoriesLayout.m; sourceTree = "<group>"; };
 		484A10C01C4C47AD00948ED4 /* DDGStoryMenu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDGStoryMenu.h; sourceTree = "<group>"; };
 		484A10C11C4C47AD00948ED4 /* DDGStoryMenu.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDGStoryMenu.m; sourceTree = "<group>"; };
 		486909FE1C489CB900083D49 /* DDGTraitHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDGTraitHelper.h; sourceTree = "<group>"; };
@@ -1481,6 +1484,8 @@
 				847DA68E1C1060940091F55F /* DDGCollectionView.m */,
 				484A10C01C4C47AD00948ED4 /* DDGStoryMenu.h */,
 				484A10C11C4C47AD00948ED4 /* DDGStoryMenu.m */,
+				4849B95D1CC8774500E27C5C /* DDGStoriesLayout.h */,
+				4849B95E1CC8774500E27C5C /* DDGStoriesLayout.m */,
 			);
 			name = Stories;
 			sourceTree = "<group>";
@@ -2151,6 +2156,7 @@
 				83F32269149290EF00A61BC5 /* main.m in Sources */,
 				7BB873FD19374F04000C4DC4 /* DDGHTTPRequestManager.m in Sources */,
 				83F3226D149290EF00A61BC5 /* DDGAppDelegate.m in Sources */,
+				4849B95F1CC8774500E27C5C /* DDGStoriesLayout.m in Sources */,
 				83F3229E1492EE1B00A61BC5 /* DDGSearchController.m in Sources */,
 				839819431493C1DB0017A892 /* DDGWebViewController.m in Sources */,
 				4CCEA043150AAB1D00CCC480 /* DDGSearchSuggestionsProvider.m in Sources */,

--- a/DuckDuckGo/DDGAppDelegate.m
+++ b/DuckDuckGo/DDGAppDelegate.m
@@ -153,6 +153,39 @@ static void uncaughtExceptionHandler(NSException *exception) {
     return YES;
 }
 
+
+- (BOOL)application:(UIApplication *)application
+continueUserActivity:(NSUserActivity *)userActivity
+ restorationHandler:(void (^)(NSArray *restorableObjects))restorationHandler
+{
+    NSURL* url = userActivity.webpageURL;
+    NSLog(@"deep-linking invoked with URL: %@", url);
+    
+    //We can only open URLs from DDG.
+    BOOL isDDGURL = [[[url scheme] lowercaseString] isEqualToString:@"duckduckgo"];
+    
+    // Let's see what the query is.
+    NSString *query = nil;
+    if(isDDGURL) {
+        NSArray *params = [[url query] componentsSeparatedByString:@"&"];
+        for (NSString *param in params) {
+            NSArray *pair = [param componentsSeparatedByString:@"="];
+            if ([pair count] > 1 && [[[pair objectAtIndex:0] lowercaseString] isEqualToString:@"q"]) {
+                query = [[pair objectAtIndex:1] URLDecodedStringDDG];
+            }
+        }
+    }
+    
+    if (query) {
+        [self.homeController.currentSearchHandler loadQueryOrURL:query];
+    } else {
+        [self.homeController.currentSearchHandler loadQueryOrURL:[url absoluteString]];
+    }
+    
+    return YES;
+}
+
+
 - (void)applicationWillTerminate:(UIApplication *)application;
 {
     [self save];

--- a/DuckDuckGo/DDGAppDelegate.m
+++ b/DuckDuckGo/DDGAppDelegate.m
@@ -164,7 +164,6 @@ continueUserActivity:(NSUserActivity *)userActivity
     
     //We can only open URLs from DDG.
     BOOL isDDGURL = [[[url scheme] lowercaseString] isEqualToString:@"duckduckgo"];
-    
     // Let's see what the query is.
     NSString *query = nil;
     if(isDDGURL) {
@@ -175,6 +174,8 @@ continueUserActivity:(NSUserActivity *)userActivity
                 query = [[pair objectAtIndex:1] URLDecodedStringDDG];
             }
         }
+    } else {
+        query = [DDGSearchController queryFromDDGURL:url];
     }
     
     if (query) {

--- a/DuckDuckGo/DDGAppDelegate.m
+++ b/DuckDuckGo/DDGAppDelegate.m
@@ -160,6 +160,7 @@ continueUserActivity:(NSUserActivity *)userActivity
 {
     NSURL* url = userActivity.webpageURL;
     NSLog(@"deep-linking invoked with URL: %@", url);
+    if(url==nil) return NO;
     
     //We can only open URLs from DDG.
     BOOL isDDGURL = [[[url scheme] lowercaseString] isEqualToString:@"duckduckgo"];

--- a/DuckDuckGo/DDGSearchBar.m
+++ b/DuckDuckGo/DDGSearchBar.m
@@ -56,7 +56,7 @@
 
 - (void)setShowsBangButton:(BOOL)show animated:(BOOL)animated {
     self.searchField.additionalLeftSideInset = show ? 39 : 0;
-    [self layoutIfNeeded];
+    // [self layoutIfNeeded];
     _showsBangButton = show;
     [self setNeedsLayout];
     [self layoutIfNeeded:(animated ? 0.2 : 0)];

--- a/DuckDuckGo/DDGSearchController.h
+++ b/DuckDuckGo/DDGSearchController.h
@@ -77,7 +77,7 @@ typedef enum {
 // helper methods
 -(NSString *)validURLStringFromString:(NSString *)urlString;
 -(BOOL)isQuery:(NSString *)queryOrURL;
--(NSString *)queryFromDDGURL:(NSURL *)url;
++(NSString *)queryFromDDGURL:(NSURL *)url;
 
 -(void)searchFieldDidChange:(id)sender;
 -(void)dismissKeyboard:(void (^)(BOOL completed))completion;

--- a/DuckDuckGo/DDGSearchController.m
+++ b/DuckDuckGo/DDGSearchController.m
@@ -465,9 +465,6 @@ NSString * const emailRegEx =
 
 -(void)keyboardWillHide:(NSNotification *)notification {
     [self keyboardIsShowing:NO notification:notification];
-    if (autocompleteOpen) {
-        [self dismissAutocomplete];
-    }
 }
 
 -(void)keyboardDidHide:(NSNotification *)notification {
@@ -560,6 +557,8 @@ NSString * const emailRegEx =
 }
 
 -(void)loadQueryOrURL:(NSString *)queryOrURLString {
+    [self.searchBar.searchField resignFirstResponder];
+    
     UIViewController *contentViewController = self.navController.visibleViewController;
     if ([contentViewController conformsToProtocol:@protocol(DDGSearchHandler)]) {
         [(UIViewController <DDGSearchHandler> *)contentViewController loadQueryOrURL:queryOrURLString];
@@ -1104,7 +1103,9 @@ NSString * const emailRegEx =
 }
 
 - (void)textFieldDidEndEditing:(UITextField *)textField {
-    
+    if (autocompleteOpen) {
+        [self dismissAutocomplete];
+    }
 }
 
 - (BOOL)textFieldShouldReturn:(UITextField *)textField {

--- a/DuckDuckGo/DDGSearchController.m
+++ b/DuckDuckGo/DDGSearchController.m
@@ -736,7 +736,7 @@ NSString * const emailRegEx =
     return ![self validURLStringFromString:queryOrURL];
 }
 
--(NSString *)queryFromDDGURL:(NSURL *)url {
++(NSString *)queryFromDDGURL:(NSURL *)url {
     // parse URL query components
     NSArray *queryComponentsArray = [[url query] componentsSeparatedByString:@"&"];
     NSMutableDictionary *queryComponents = [[NSMutableDictionary alloc] init];
@@ -748,20 +748,12 @@ NSString * const emailRegEx =
     
     // check whether we have a DDG search URL
     if([[url host] isEqualToString:@"duckduckgo.com"]) {
-        if([[url path] isEqualToString:@"/"] && [queryComponents objectForKey:@"q"]) {
+        if(([[url path] isEqualToString:@"/"] || [[url path] isEqualToString:@"/ioslinks"]) && [queryComponents objectForKey:@"q"]) {
             // yep! extract the search query...
             NSString *query = [queryComponents objectForKey:@"q"];
             query = [query stringByReplacingOccurrencesOfString:@"+" withString:@"%20"];
             query = [query stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
             
-            return query;
-        } else if(![[url pathExtension] isEqualToString:@"html"]) {
-            // article page
-            NSString *query = [url path];
-            if ([query length] > 1)
-                query = [query substringFromIndex:1]; // strip the leading '/' in the URL
-            query = [query stringByReplacingOccurrencesOfString:@"_" withString:@"%20"];
-            query = [query stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];            
             return query;
         } else {
             // a URL on DDG.com, but not a search query
@@ -920,7 +912,7 @@ NSString * const emailRegEx =
 
 -(void)updateBarWithURL:(NSURL *)url {
     barUpdated = YES;
-    NSString *query = [self queryFromDDGURL:url];
+    NSString *query = [DDGSearchController queryFromDDGURL:url];
     NSString *headerText = (query ? query : url.absoluteString);
     [self.searchBar.searchField safeUpdateText:headerText];
     oldSearchText = headerText;

--- a/DuckDuckGo/DDGSettingsViewController.m
+++ b/DuckDuckGo/DDGSettingsViewController.m
@@ -263,15 +263,17 @@ NSString * const DDGSettingHomeViewTypeDuck = @"Duck Mode";
         [s.switchControl addTarget:self action:@selector(save:) forControlEvents:UIControlEventValueChanged];
     
     [self addSectionWithTitle:NSLocalizedString(@"Other", @"Heading for Other options section") footer:nil];
-    
-    [self addButton:NSLocalizedString(@"Send Feedback", @"Button: Send Feedback") forKey:@"feedback" detailTitle:nil type:IGFormButtonTypeNormal action:^{
-        MFMailComposeViewController *mailVC = [[MFMailComposeViewController alloc] init];
-        mailVC.mailComposeDelegate = weakSelf;
-        [mailVC setToRecipients:@[@"help@duckduckgo.com"]];
-        [mailVC setSubject:@"DuckDuckGo for iOS feedback"];
-        [mailVC setMessageBody:[NSString stringWithFormat:@"I'm running %@. Here's my feedback:",[weakSelf deviceInfo]] isHTML:NO];
-        [weakSelf presentViewController:mailVC animated:YES completion:NULL];
-    }];
+
+    if ([MFMailComposeViewController canSendMail]) {
+        [self addButton:NSLocalizedString(@"Send Feedback", @"Button: Send Feedback") forKey:@"feedback" detailTitle:nil type:IGFormButtonTypeNormal action:^{
+            MFMailComposeViewController *mailVC = [[MFMailComposeViewController alloc] init];
+            mailVC.mailComposeDelegate = weakSelf;
+            [mailVC setToRecipients:@[@"help@duckduckgo.com"]];
+            [mailVC setSubject:@"DuckDuckGo for iOS feedback"];
+            [mailVC setMessageBody:[NSString stringWithFormat:@"I'm running %@. Here's my feedback:", [weakSelf deviceInfo]] isHTML:NO];
+            [weakSelf presentViewController:mailVC animated:YES completion:NULL];
+        }];
+    }
     
     [self addButton:NSLocalizedString(@"Share", @"Button: Share") forKey:@"share" detailTitle:nil type:IGFormButtonTypeNormal action:^{
         NSString *shareTitle = NSLocalizedString(@"Check out the DuckDuckGo iOS app!", @"Share title: Check out the DuckDuckGo iOS app!");

--- a/DuckDuckGo/DDGSettingsViewController.m
+++ b/DuckDuckGo/DDGSettingsViewController.m
@@ -179,10 +179,8 @@ NSString * const DDGSettingHomeViewTypeDuck = @"Duck Mode";
 {
     if(self.splitViewController) {
         if(![DDGTraitHelper isFullScreeniPad:self.traitCollection]) {
-            NSLog(@"Is not a full screen iPad but has a split view controller..");
             [self.searchControllerDDG pushContentViewController:secondaryViewController animated:TRUE];
-        } else {
-            NSLog(@"is a full screen iPad so lets load the detail view...");
+        } else {            
             [self.splitViewController setDetailViewController:secondaryViewController];
             
             // Ensure that the tab bar is actually on the top level, especially after changing detail controllers

--- a/DuckDuckGo/DDGStoriesLayout.h
+++ b/DuckDuckGo/DDGStoriesLayout.h
@@ -1,0 +1,21 @@
+//
+//  DDGStoriesLayout.h
+//  DuckDuckGo
+//
+//  Created by Johnnie Walker on 06/03/2013.
+//  Extended by Josiah Clumont from 21/04/16.
+//
+//
+
+#import <UIKit/UIKit.h>
+#import "DDGStoriesViewController.h"
+
+@interface DDGStoriesLayout : UICollectionViewLayout
+
+@property (nonatomic, weak) DDGStoriesViewController* storiesController;
+@property BOOL mosaicMode;
+@property (nonatomic, strong) NSDictionary *layoutInfo;
+
+- (CGRect)frameForStoryAtIndexPath:(NSIndexPath *)indexPath;
+
+@end

--- a/DuckDuckGo/DDGStoriesLayout.m
+++ b/DuckDuckGo/DDGStoriesLayout.m
@@ -1,0 +1,180 @@
+//
+//  DDGStoriesLayout.m
+//  DuckDuckGo
+//
+//  Created by Johnnie Walker on 06/03/2013.
+//  Extended by Josiah Clumont from 21/04/16.
+//
+
+#import "DDGStoriesLayout.h"
+#import "DDGStoriesViewController.h"
+
+#pragma mark DDGStoriesLayout
+
+static NSString * const DDGStoriesLayoutKind = @"PhotoCell";
+
+
+@implementation DDGStoriesLayout
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        [self setup];
+    }
+    
+    return self;
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super init];
+    if (self) {
+        [self setup];
+    }
+    
+    return self;
+}
+
+- (void)setup
+{
+    self.mosaicMode = TRUE;
+}
+
+- (void)prepareLayout
+{
+    NSMutableDictionary *newLayoutInfo = [NSMutableDictionary dictionary];
+    NSMutableDictionary *cellLayoutInfo = [NSMutableDictionary dictionary];
+    
+    NSInteger sectionCount = [self.collectionView numberOfSections];
+    
+    for (NSInteger section = 0; section < sectionCount; section++) {
+        NSInteger itemCount = [self.collectionView numberOfItemsInSection:section];
+        
+        for (NSInteger item = 0; item < itemCount; item++) {
+            NSIndexPath* indexPath = [NSIndexPath indexPathForItem:item inSection:0];
+            UICollectionViewLayoutAttributes* itemAttributes =
+            [UICollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:indexPath];
+            itemAttributes.frame = [self frameForStoryAtIndexPath:indexPath];
+            
+            cellLayoutInfo[indexPath] = itemAttributes;
+        }
+    }
+    
+    newLayoutInfo[DDGStoriesLayoutKind] = cellLayoutInfo;
+    
+    self.layoutInfo = newLayoutInfo;
+}
+
+
+CGFloat DDG_rowHeightWithContainerSize(CGSize size) {
+    BOOL mosaicMode = size.width >= DDGStoriesMulticolumnWidthThreshold;
+    CGFloat rowHeight;
+    if(mosaicMode) { // set to the height of the larger story
+        rowHeight = ((size.width - DDGStoriesBetweenItemsSpacing)*2/3) / DDGStoryImageWithoutTitleRatio + DDGTitleBarHeightMosaicLarge;
+    } else { // set to the height
+        rowHeight = size.width / DDGStoryImageRatio + DDGTitleBarHeight;
+    }
+    return MAX(10.0f, rowHeight); // a little safety
+}
+
+- (CGSize)collectionViewContentSize
+{
+    NSUInteger numStories = [self.collectionView numberOfItemsInSection:0];
+    CGSize size = self.collectionView.frame.size;
+    self.mosaicMode = size.width >= DDGStoriesMulticolumnWidthThreshold;
+    NSUInteger cellsPerRow = self.mosaicMode ? 3 : 1;
+    CGFloat rowHeight = DDG_rowHeightWithContainerSize(size) + DDGStoriesBetweenItemsSpacing;
+    NSUInteger numRows = numStories/cellsPerRow;
+    if(numStories%cellsPerRow!=0) numRows++;
+    size.height = rowHeight * numRows;
+    return size;
+}
+
+
+
+- (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect
+{
+    NSMutableArray* elementAttributes = [NSMutableArray new];
+    CGSize size = self.collectionView.frame.size;
+    BOOL mosaicMode = size.width >= DDGStoriesMulticolumnWidthThreshold;
+    CGFloat rowHeight = DDG_rowHeightWithContainerSize(size) + DDGStoriesBetweenItemsSpacing;
+    
+    NSUInteger cellsPerRow = mosaicMode ? 3 : 1;
+    NSUInteger rowsBeforeRect = floor(rect.origin.y / rowHeight);
+    NSUInteger rowsWithinRect = ceil((rect.origin.y+rect.size.height) / rowHeight) - rowsBeforeRect + 1;
+    
+    for(NSUInteger row = rowsBeforeRect; row < rowsBeforeRect + rowsWithinRect; row++) {
+        for(NSUInteger column = 0 ; column < cellsPerRow; column++) {
+            NSUInteger storyIndex = row * cellsPerRow + column;
+            if(storyIndex >= [self.collectionView numberOfItemsInSection:0]) break;
+            UICollectionViewLayoutAttributes* attributes = [self layoutAttributesForItemAtIndexPath:[NSIndexPath indexPathForItem:storyIndex inSection:0]];
+            [elementAttributes addObject:attributes];
+        }
+    }
+    return elementAttributes;
+}
+
+
+- (UICollectionViewLayoutAttributes *)layoutAttributesForItemAtIndexPath:(NSIndexPath *)indexPath
+{
+    UICollectionViewLayoutAttributes *itemAttributes = [UICollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:indexPath];
+    itemAttributes.frame = [self frameForStoryAtIndexPath:indexPath];
+    return itemAttributes;
+}
+
+- (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds
+{
+    return TRUE; // re-layout for all bounds changes
+}
+
+- (CGRect)frameForStoryAtIndexPath:(NSIndexPath *)indexPath
+{
+    NSUInteger row = indexPath.item;
+    if(row==NSNotFound) return CGRectZero;
+    row = row / (self.mosaicMode ? 3 : 1);
+    NSInteger column = indexPath.item % (self.mosaicMode ? 3 : 1);
+    CGSize frameSize = self.collectionView.frame.size;
+    CGFloat rowHeight = DDG_rowHeightWithContainerSize(frameSize);
+    CGFloat rowWidth = frameSize.width;
+    BOOL oddRow = (row % 2) == 1;
+    
+    CGRect storyRect = CGRectMake(0, row * (rowHeight + DDGStoriesBetweenItemsSpacing),
+                                  rowWidth, rowHeight);
+    if(self.mosaicMode) {
+        if(oddRow) {
+            if(column==0) { // top left of three
+                storyRect.size.width = (rowWidth - DDGStoriesBetweenItemsSpacing)/3;
+                storyRect.size.height = (rowHeight - DDGStoriesBetweenItemsSpacing)/2;
+            } else if(column==1) { // bottom left of three
+                storyRect.size.width = (rowWidth - DDGStoriesBetweenItemsSpacing)/3;
+                storyRect.size.height = (rowHeight - DDGStoriesBetweenItemsSpacing)/2;
+                storyRect.origin.y += rowHeight - storyRect.size.height;
+            } else { // if(column==2) // the large right-side story
+                storyRect.size.width = (rowWidth - DDGStoriesBetweenItemsSpacing)*2/3;
+                storyRect.origin.x += rowWidth - storyRect.size.width;
+            }
+        } else { // even row
+            if(column==1) { // top right of three
+                storyRect.size.width = (rowWidth - DDGStoriesBetweenItemsSpacing)/3;
+                storyRect.size.height = (rowHeight - DDGStoriesBetweenItemsSpacing)/2;
+                storyRect.origin.x += rowWidth - storyRect.size.width;
+            } else if(column==2) { // bottom right of three
+                storyRect.size.width = (rowWidth - DDGStoriesBetweenItemsSpacing)/3;
+                storyRect.size.height = (rowHeight - DDGStoriesBetweenItemsSpacing)/2;
+                storyRect.origin.y += rowHeight - storyRect.size.height;
+                storyRect.origin.x += rowWidth - storyRect.size.width;
+            } else { // if(column==0) // the large left-side story
+                storyRect.size.width = (rowWidth - DDGStoriesBetweenItemsSpacing)*2/3;
+            }
+        }
+        storyRect.origin.y += DDGStoriesBetweenItemsSpacing;
+    } else { // not a mosaic
+        // the defaults are good enough
+    }
+    
+    return storyRect;
+}
+
+
+@end

--- a/DuckDuckGo/DDGStoriesViewController.m
+++ b/DuckDuckGo/DDGStoriesViewController.m
@@ -23,6 +23,8 @@
 #import <CoreImage/CoreImage.h>
 #import "DDGTableView.h"
 #import "DDGCollectionView.h"
+#import "DDGStoriesLayout.h"
+#import "DDGConstraintHelper.h"
 
 NSTimeInterval const DDGMinimumRefreshInterval = 30;
 
@@ -60,187 +62,6 @@ NSInteger const DDGLargeImageViewTag = 1;
 @property (nonatomic, assign) BOOL ignoreCoreDataUpdates;
 
 @end
-
-
-
-#pragma mark DDGStoriesLayout
-
-static NSString * const DDGStoriesLayoutKind = @"PhotoCell";
-
-
-@interface DDGStoriesLayout : UICollectionViewLayout
-@property (nonatomic, weak) DDGStoriesViewController* storiesController;
-@property BOOL mosaicMode;
-@property (nonatomic, strong) NSDictionary *layoutInfo;
-
-@end
-
-
-@implementation DDGStoriesLayout
-
-- (id)init
-{
-    self = [super init];
-    if (self) {
-        [self setup];
-    }
-    
-    return self;
-}
-
-- (id)initWithCoder:(NSCoder *)aDecoder
-{
-    self = [super init];
-    if (self) {
-        [self setup];
-    }
-    
-    return self;
-}
-
-- (void)setup
-{
-    self.mosaicMode = TRUE;
-}
-
-- (void)prepareLayout
-{
-    NSMutableDictionary *newLayoutInfo = [NSMutableDictionary dictionary];
-    NSMutableDictionary *cellLayoutInfo = [NSMutableDictionary dictionary];
-    
-    NSInteger sectionCount = [self.collectionView numberOfSections];
-    
-    for (NSInteger section = 0; section < sectionCount; section++) {
-        NSInteger itemCount = [self.collectionView numberOfItemsInSection:section];
-        
-        for (NSInteger item = 0; item < itemCount; item++) {
-            NSIndexPath* indexPath = [NSIndexPath indexPathForItem:item inSection:0];
-            UICollectionViewLayoutAttributes* itemAttributes =
-            [UICollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:indexPath];
-            itemAttributes.frame = [self frameForStoryAtIndexPath:indexPath];
-            
-            cellLayoutInfo[indexPath] = itemAttributes;
-        }
-    }
-    
-    newLayoutInfo[DDGStoriesLayoutKind] = cellLayoutInfo;
-    
-    self.layoutInfo = newLayoutInfo;
-}
-
-
-CGFloat DDG_rowHeightWithContainerSize(CGSize size) {
-    BOOL mosaicMode = size.width >= DDGStoriesMulticolumnWidthThreshold;
-    CGFloat rowHeight;
-    if(mosaicMode) { // set to the height of the larger story
-        rowHeight = ((size.width - DDGStoriesBetweenItemsSpacing)*2/3) / DDGStoryImageWithoutTitleRatio + DDGTitleBarHeightMosaicLarge;
-    } else { // set to the height
-        rowHeight = size.width / DDGStoryImageRatio + DDGTitleBarHeight;
-    }
-    return MAX(10.0f, rowHeight); // a little safety
-}
-
-- (CGSize)collectionViewContentSize
-{
-    NSUInteger numStories = [self.collectionView numberOfItemsInSection:0];
-    CGSize size = self.collectionView.frame.size;
-    self.mosaicMode = size.width >= DDGStoriesMulticolumnWidthThreshold;
-    NSUInteger cellsPerRow = self.mosaicMode ? 3 : 1;
-    CGFloat rowHeight = DDG_rowHeightWithContainerSize(size) + DDGStoriesBetweenItemsSpacing;
-    NSUInteger numRows = numStories/cellsPerRow;
-    if(numStories%cellsPerRow!=0) numRows++;
-    size.height = rowHeight * numRows;
-    return size;
-}
-
-
-
-- (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect
-{
-    NSMutableArray* elementAttributes = [NSMutableArray new];
-    CGSize size = self.collectionView.frame.size;
-    BOOL mosaicMode = size.width >= DDGStoriesMulticolumnWidthThreshold;
-    CGFloat rowHeight = DDG_rowHeightWithContainerSize(size) + DDGStoriesBetweenItemsSpacing;
-    
-    NSUInteger cellsPerRow = mosaicMode ? 3 : 1;
-    NSUInteger rowsBeforeRect = floor(rect.origin.y / rowHeight);
-    NSUInteger rowsWithinRect = ceil((rect.origin.y+rect.size.height) / rowHeight) - rowsBeforeRect + 1;
-    
-    for(NSUInteger row = rowsBeforeRect; row < rowsBeforeRect + rowsWithinRect; row++) {
-        for(NSUInteger column = 0 ; column < cellsPerRow; column++) {
-            NSUInteger storyIndex = row * cellsPerRow + column;
-            if(storyIndex >= [self.collectionView numberOfItemsInSection:0]) break;
-            UICollectionViewLayoutAttributes* attributes = [self layoutAttributesForItemAtIndexPath:[NSIndexPath indexPathForItem:storyIndex inSection:0]];
-            [elementAttributes addObject:attributes];
-        }
-    }
-    return elementAttributes;
-}
-
-
-- (UICollectionViewLayoutAttributes *)layoutAttributesForItemAtIndexPath:(NSIndexPath *)indexPath
-{
-    UICollectionViewLayoutAttributes *itemAttributes = [UICollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:indexPath];
-    itemAttributes.frame = [self frameForStoryAtIndexPath:indexPath];
-    return itemAttributes;
-}
-
-- (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds
-{
-    return TRUE; // re-layout for all bounds changes
-}
-
-- (CGRect)frameForStoryAtIndexPath:(NSIndexPath *)indexPath
-{
-    NSUInteger row = indexPath.item;
-    if(row==NSNotFound) return CGRectZero;
-    row = row / (self.mosaicMode ? 3 : 1);
-    NSInteger column = indexPath.item % (self.mosaicMode ? 3 : 1);
-    CGSize frameSize = self.collectionView.frame.size;
-    CGFloat rowHeight = DDG_rowHeightWithContainerSize(frameSize);
-    CGFloat rowWidth = frameSize.width;
-    BOOL oddRow = (row % 2) == 1;
-    
-    CGRect storyRect = CGRectMake(0, row * (rowHeight + DDGStoriesBetweenItemsSpacing),
-                                  rowWidth, rowHeight);
-    if(self.mosaicMode) {
-        if(oddRow) {
-            if(column==0) { // top left of three
-                storyRect.size.width = (rowWidth - DDGStoriesBetweenItemsSpacing)/3;
-                storyRect.size.height = (rowHeight - DDGStoriesBetweenItemsSpacing)/2;
-            } else if(column==1) { // bottom left of three
-                storyRect.size.width = (rowWidth - DDGStoriesBetweenItemsSpacing)/3;
-                storyRect.size.height = (rowHeight - DDGStoriesBetweenItemsSpacing)/2;
-                storyRect.origin.y += rowHeight - storyRect.size.height;
-            } else { // if(column==2) // the large right-side story
-                storyRect.size.width = (rowWidth - DDGStoriesBetweenItemsSpacing)*2/3;
-                storyRect.origin.x += rowWidth - storyRect.size.width;
-            }
-        } else { // even row
-            if(column==1) { // top right of three
-                storyRect.size.width = (rowWidth - DDGStoriesBetweenItemsSpacing)/3;
-                storyRect.size.height = (rowHeight - DDGStoriesBetweenItemsSpacing)/2;
-                storyRect.origin.x += rowWidth - storyRect.size.width;
-            } else if(column==2) { // bottom right of three
-                storyRect.size.width = (rowWidth - DDGStoriesBetweenItemsSpacing)/3;
-                storyRect.size.height = (rowHeight - DDGStoriesBetweenItemsSpacing)/2;
-                storyRect.origin.y += rowHeight - storyRect.size.height;
-                storyRect.origin.x += rowWidth - storyRect.size.width;
-            } else { // if(column==0) // the large left-side story
-                storyRect.size.width = (rowWidth - DDGStoriesBetweenItemsSpacing)*2/3;
-            }
-        }
-        storyRect.origin.y += DDGStoriesBetweenItemsSpacing;
-    } else { // not a mosaic
-        // the defaults are good enough
-    }
-    
-    return storyRect;
-}
-
-
-@end
-
 
 
 
@@ -490,7 +311,10 @@ CGFloat DDG_rowHeightWithContainerSize(CGSize size) {
     storyView.backgroundColor = [UIColor duckStoriesBackground];
     storyView.dataSource = self;
     storyView.delegate = self;
-    storyView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    [storyView setTranslatesAutoresizingMaskIntoConstraints:NO];
+//    storyView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    
+    
     [storyView registerClass:DDGStoryCell.class forCellWithReuseIdentifier:DDGStoryCellIdentifier];
     
     self.storyView = storyView;
@@ -522,6 +346,7 @@ CGFloat DDG_rowHeightWithContainerSize(CGSize size) {
     self.noContentView.view.frame = self.view.bounds;
     
     [self.view addSubview:self.storyView];
+    [DDGConstraintHelper pinView:storyView intoView:self.view];
     [self.view addSubview:self.noContentView.view];
     
     self.ignoreCoreDataUpdates = TRUE;

--- a/DuckDuckGo/DDGStoriesViewController.m
+++ b/DuckDuckGo/DDGStoriesViewController.m
@@ -433,6 +433,7 @@ NSInteger const DDGLargeImageViewTag = 1;
     [self.imageDownloadQueue cancelAllOperations];
     [self.enqueuedDownloadOperations removeAllObjects];
     self.fetchedResultsController.delegate = nil;
+    self.fetchedResultsController = nil;
 }
 
 - (void)viewDidDisappear:(BOOL)animated

--- a/DuckDuckGo/DDGStory.m
+++ b/DuckDuckGo/DDGStory.m
@@ -166,13 +166,12 @@
           NSLog(@"Error excluding %@ from backup %@", url, error);
         }
       }
-      
       dispatch_async(dispatch_get_main_queue(), ^{
-        [self.managedObjectContext performBlockAndWait:^{
+        [self.managedObjectContext performBlockAndWait:^{            
           self.htmlDownloadedValue = YES;
         }];
+          if (completion) completion(result);
       });
-    if (completion) completion(result);        
     });
 }
 

--- a/DuckDuckGo/DDGStoryCell.m
+++ b/DuckDuckGo/DDGStoryCell.m
@@ -265,7 +265,7 @@ NSString *const DDGStoryCellIdentifier = @"StoryCell";
 
 #pragma mark -
 
-- (void)layoutSubviews;
+- (void)layoutSubviews
 {
     // Always call your parents.
     [super layoutSubviews];

--- a/DuckDuckGo/DDGTabViewController.m
+++ b/DuckDuckGo/DDGTabViewController.m
@@ -99,7 +99,6 @@
 - (void)setCurrentViewControllerIndex:(NSInteger)newViewControllerIndex {
     NSAssert1(newViewControllerIndex < [self.viewControllers count], @"Attempt to select a view controller beyond range of tabViewControllers %ld", (long)newViewControllerIndex);    
     self.tabController.selectedIndex = newViewControllerIndex;
-    [self.tabController.selectedViewController viewDidAppear:false];
     [self.segmentedControl setSelectedSegmentIndex:newViewControllerIndex];
 }
 

--- a/DuckDuckGo/DDGTabViewController.m
+++ b/DuckDuckGo/DDGTabViewController.m
@@ -97,8 +97,9 @@
 }
 
 - (void)setCurrentViewControllerIndex:(NSInteger)newViewControllerIndex {
-    NSAssert1(newViewControllerIndex < [self.viewControllers count], @"Attempt to select a view controller beyond range of tabViewControllers %ld", (long)newViewControllerIndex);
+    NSAssert1(newViewControllerIndex < [self.viewControllers count], @"Attempt to select a view controller beyond range of tabViewControllers %ld", (long)newViewControllerIndex);    
     self.tabController.selectedIndex = newViewControllerIndex;
+    [self.tabController.selectedViewController viewDidAppear:false];
     [self.segmentedControl setSelectedSegmentIndex:newViewControllerIndex];
 }
 

--- a/DuckDuckGo/DDGToolbarAndNavigationBarAutohider.m
+++ b/DuckDuckGo/DDGToolbarAndNavigationBarAutohider.m
@@ -59,12 +59,7 @@
     } else if(offset.y  > lastOffset.y) {
         // we're scrolling down... hide the toolbar, unless we're already very close to the bottom
         CGFloat contentHeight = scrollView.contentSize.height - scrollView.frame.size.height;
-        BOOL atBottom =  false;
-        CGFloat distanceToTheBottom = contentHeight - offset.y;
-        if (distanceToTheBottom < 100) {
-            atBottom = true;
-        }
-        
+        BOOL atBottom =  offset.y+100 >= contentHeight;        
         lastUpwardsScrollDistance = 0;
         [self.toolbarAndNavigationBarHiderDelegate setHideToolbarAndNavigationBar:!atBottom forScrollview:scrollView];
     } else if (offset.y > 0 && offset.y <= scrollView.contentSize.height+scrollView.frame.size.height+50) {

--- a/DuckDuckGo/DDGToolbarAndNavigationBarAutohider.m
+++ b/DuckDuckGo/DDGToolbarAndNavigationBarAutohider.m
@@ -14,6 +14,7 @@
     CGFloat lastUpwardsScrollDistance;
 }
 
+@property CGFloat previousContentHeight;
 @property UIView* containerView;
 @property UIScrollView* scrollView;
 @property NSLayoutConstraint* topToolbarBottomConstraint;
@@ -57,7 +58,13 @@
         [self.toolbarAndNavigationBarHiderDelegate setHideToolbarAndNavigationBar:FALSE forScrollview:scrollView];
     } else if(offset.y  > lastOffset.y) {
         // we're scrolling down... hide the toolbar, unless we're already very close to the bottom
-        BOOL atBottom =  offset.y+50 >= (scrollView.contentSize.height - scrollView.frame.size.height);
+        CGFloat contentHeight = scrollView.contentSize.height - scrollView.frame.size.height;
+        BOOL atBottom =  false;
+        CGFloat distanceToTheBottom = contentHeight - offset.y;
+        if (distanceToTheBottom < 100) {
+            atBottom = true;
+        }
+        
         lastUpwardsScrollDistance = 0;
         [self.toolbarAndNavigationBarHiderDelegate setHideToolbarAndNavigationBar:!atBottom forScrollview:scrollView];
     } else if (offset.y > 0 && offset.y <= scrollView.contentSize.height+scrollView.frame.size.height+50) {

--- a/DuckDuckGo/DDGToolbarAndNavigationBarAutohider.m
+++ b/DuckDuckGo/DDGToolbarAndNavigationBarAutohider.m
@@ -58,15 +58,12 @@
         [self.toolbarAndNavigationBarHiderDelegate setHideToolbarAndNavigationBar:FALSE forScrollview:scrollView];
     } else if(offset.y  > lastOffset.y) {
         // we're scrolling down... hide the toolbar, unless we're already very close to the bottom
-        CGFloat contentHeight = scrollView.contentSize.height - scrollView.frame.size.height;
-        BOOL atBottom =  false;
-        CGFloat distanceToTheBottom = contentHeight - offset.y;
-        if (distanceToTheBottom < 100) {
-            atBottom = true;
-        }
-        
+        CGFloat distanceFromBottom = scrollView.contentSize.height - (offset.y + scrollView.frame.size.height);
+        BOOL atBottom = distanceFromBottom <= 50;
+        BOOL nearBottom = distanceFromBottom <= 110;
         lastUpwardsScrollDistance = 0;
-        [self.toolbarAndNavigationBarHiderDelegate setHideToolbarAndNavigationBar:!atBottom forScrollview:scrollView];
+        // don't change the hidden status if we are near but not at the bottom. avoids thrashing when the scrollview is adjusting after showing the toolbar
+        if(atBottom || !nearBottom) [self.toolbarAndNavigationBarHiderDelegate setHideToolbarAndNavigationBar:!atBottom forScrollview:scrollView];
     } else if (offset.y > 0 && offset.y <= scrollView.contentSize.height+scrollView.frame.size.height+50) {
         // we're scrolling up... show the toolbar if we've gone past a certain threshold
         lastUpwardsScrollDistance += (lastOffset.y - offset.y);

--- a/DuckDuckGo/DDGToolbarAndNavigationBarAutohider.m
+++ b/DuckDuckGo/DDGToolbarAndNavigationBarAutohider.m
@@ -59,7 +59,12 @@
     } else if(offset.y  > lastOffset.y) {
         // we're scrolling down... hide the toolbar, unless we're already very close to the bottom
         CGFloat contentHeight = scrollView.contentSize.height - scrollView.frame.size.height;
-        BOOL atBottom =  offset.y+100 >= contentHeight;        
+        BOOL atBottom =  false;
+        CGFloat distanceToTheBottom = contentHeight - offset.y;
+        if (distanceToTheBottom < 100) {
+            atBottom = true;
+        }
+        
         lastUpwardsScrollDistance = 0;
         [self.toolbarAndNavigationBarHiderDelegate setHideToolbarAndNavigationBar:!atBottom forScrollview:scrollView];
     } else if (offset.y > 0 && offset.y <= scrollView.contentSize.height+scrollView.frame.size.height+50) {

--- a/DuckDuckGo/DDGWebKitWebViewController.m
+++ b/DuckDuckGo/DDGWebKitWebViewController.m
@@ -110,6 +110,7 @@
     self.webView                = webKitView;
     self.webView.UIDelegate     = self;
     self.webView.navigationDelegate = self;
+    self.webView.scrollView.bounces = false;
     [self.webView setBackgroundColor:[UIColor duckNoContentColor]];
     
     _webViewLoadingDepth = 0;

--- a/DuckDuckGo/DDGWebKitWebViewController.m
+++ b/DuckDuckGo/DDGWebKitWebViewController.m
@@ -109,8 +109,7 @@
     webKitView.webKitController = self;
     self.webView                = webKitView;
     self.webView.UIDelegate     = self;
-    self.webView.navigationDelegate = self;
-    self.webView.scrollView.bounces = false;
+    self.webView.navigationDelegate = self;    
     [self.webView setBackgroundColor:[UIColor duckNoContentColor]];
     
     _webViewLoadingDepth = 0;
@@ -215,6 +214,13 @@
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [operation start];
     });
+}
+
+- (void)loadWebViewWithUrl:(NSURL*)url {
+    NSURLRequest *request = [DDGUtility requestWithURL:url];
+    [self.webView loadRequest:request];
+    [self.searchController updateBarWithURL:url];
+    self.webViewURL = url;
 }
 
 #pragma mark == WKUIDelegate ==

--- a/DuckDuckGo/DDGWebKitWebViewController.m
+++ b/DuckDuckGo/DDGWebKitWebViewController.m
@@ -110,7 +110,6 @@
     self.webView                = webKitView;
     self.webView.UIDelegate     = self;
     self.webView.navigationDelegate = self;
-    self.webView.scrollView.bounces = false;
     [self.webView setBackgroundColor:[UIColor duckNoContentColor]];
     
     _webViewLoadingDepth = 0;

--- a/DuckDuckGo/DDGWebViewController.h
+++ b/DuckDuckGo/DDGWebViewController.h
@@ -51,5 +51,5 @@
 - (NSString *)htmlFromJSON:(id)JSON;
 - (void)internalMailAction:(NSURL*)url;
 - (void)updateBarWithRequest:(NSURLRequest *)request;
-
+- (void)loadWebViewWithUrl:(NSURL*)url;
 @end

--- a/DuckDuckGo/DDGWebViewController.m
+++ b/DuckDuckGo/DDGWebViewController.m
@@ -330,10 +330,11 @@
     }
     if(self.bottomToolbarTopConstraint.constant!=newConstant) {
         self.bottomToolbarTopConstraint.constant = newConstant;
+        CGFloat toolbarBottomInset = shouldHide ? 0 : 50;
+        scrollView.contentInset = UIEdgeInsetsMake(0, 0, toolbarBottomInset, 0);
+        scrollView.scrollIndicatorInsets = UIEdgeInsetsMake(0, 0, toolbarBottomInset, 0);
         [UIView animateWithDuration:0.25 animations:^{
             [self.view layoutSubviews];
-            scrollView.contentInset = UIEdgeInsetsMake(0, 0, -newConstant, 0);
-            scrollView.scrollIndicatorInsets = UIEdgeInsetsMake(0, 0, -newConstant, 0);
         }];
     }
 }

--- a/DuckDuckGo/DDGWebViewController.m
+++ b/DuckDuckGo/DDGWebViewController.m
@@ -101,8 +101,7 @@
         self.webView.scalesPageToFit = YES;
         
         _webViewLoadingDepth = 0;
-        self.webView.backgroundColor = [UIColor duckNoContentColor];
-        self.webView.scrollView.bounces = false;
+        self.webView.backgroundColor = [UIColor duckNoContentColor];        
         
         [self.view addSubview:self.webView];
         
@@ -433,7 +432,7 @@
 -(IBAction)favButtonPressed:(id)sender {
     NSURL *shareURL = self.webViewURL;
     NSString *query = [self.searchController queryFromDDGURL:shareURL];
-    NSString *feed = [self.webViewURL absoluteString];
+    NSString *feed  = [self.webViewURL absoluteString];
     DDGBookmarkActivityItem* bookmarkItem = nil;
     if (nil != self.story && !self.webView.canGoBack) { // bookmark the story, since we're at the top level
         bookmarkItem = [DDGBookmarkActivityItem itemWithStory:self.story];
@@ -513,7 +512,6 @@
     if([self.searchController isQuery:queryOrURLString])
     {
         self.isAStory = false;
-        NSLog(@"Is not a story for querystring %@", queryOrURLString);
         // direct query
         urlString = [NSString stringWithFormat:@"https://duckduckgo.com/?q=%@&ko=-1&kl=%@",
                      [queryOrURLString URLEncodedStringDDG], 
@@ -527,6 +525,10 @@
     }
     
     NSURL *url = [NSURL URLWithString:urlString];
+    [self loadWebViewWithUrl:url];
+}
+
+- (void)loadWebViewWithUrl:(NSURL*)url {
     NSURLRequest *request = [DDGUtility requestWithURL:url];
     [self.webView loadRequest:request];
     [self.searchController updateBarWithURL:url];

--- a/DuckDuckGo/DDGWebViewController.m
+++ b/DuckDuckGo/DDGWebViewController.m
@@ -102,6 +102,7 @@
         
         _webViewLoadingDepth = 0;
         self.webView.backgroundColor = [UIColor duckNoContentColor];
+        self.webView.scrollView.bounces = false;
         
         [self.view addSubview:self.webView];
         

--- a/DuckDuckGo/DDGWebViewController.m
+++ b/DuckDuckGo/DDGWebViewController.m
@@ -358,7 +358,7 @@
 {
     // strip extra params from DDG search URLs
     NSURL *shareURL = self.webViewURL;
-    NSString *query = [self.searchController queryFromDDGURL:shareURL];
+    NSString *query = [DDGSearchController queryFromDDGURL:shareURL];
     NSString *pageTitle = [self.webView stringByEvaluatingJavaScriptFromString:@"document.title"];
     if(query) {
         NSString *escapedQuery = [query stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
@@ -432,7 +432,7 @@
 
 -(IBAction)favButtonPressed:(id)sender {
     NSURL *shareURL = self.webViewURL;
-    NSString *query = [self.searchController queryFromDDGURL:shareURL];
+    NSString *query = [DDGSearchController queryFromDDGURL:shareURL];
     NSString *feed = [self.webViewURL absoluteString];
     DDGBookmarkActivityItem* bookmarkItem = nil;
     if (nil != self.story && !self.webView.canGoBack) { // bookmark the story, since we're at the top level
@@ -732,7 +732,7 @@
     if (nil != self.story && !self.webView.canGoBack) {
         // we're at the top level of a story, so we can fave/bookmark that story
         self.isFavorited = self.story.savedValue;
-    } else { //if ([self.searchController queryFromDDGURL:self.webViewURL]) {
+    } else { //if ([DDGSearchController queryFromDDGURL:self.webViewURL]) {
         // this is a query that has been favorited/bookmarked
         self.isFavorited = [[DDGBookmarksProvider sharedProvider] bookmarkExistsForPageWithURL:self.webViewURL];
     }

--- a/DuckDuckGo/DDGWebViewController.m
+++ b/DuckDuckGo/DDGWebViewController.m
@@ -102,7 +102,6 @@
         
         _webViewLoadingDepth = 0;
         self.webView.backgroundColor = [UIColor duckNoContentColor];
-        self.webView.scrollView.bounces = false;
         
         [self.view addSubview:self.webView];
         
@@ -331,9 +330,9 @@
     if(self.bottomToolbarTopConstraint.constant!=newConstant) {
         self.bottomToolbarTopConstraint.constant = newConstant;
         CGFloat toolbarBottomInset = shouldHide ? 0 : 50;
-        scrollView.contentInset = UIEdgeInsetsMake(0, 0, toolbarBottomInset, 0);
-        scrollView.scrollIndicatorInsets = UIEdgeInsetsMake(0, 0, toolbarBottomInset, 0);
         [UIView animateWithDuration:0.25 animations:^{
+            scrollView.contentInset = UIEdgeInsetsMake(0, 0, toolbarBottomInset, 0);
+            scrollView.scrollIndicatorInsets = UIEdgeInsetsMake(0, 0, toolbarBottomInset, 0);
             [self.view layoutSubviews];
         }];
     }

--- a/DuckDuckGo/DuckDuckGo.entitlements
+++ b/DuckDuckGo/DuckDuckGo.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>DataProtectionClass</key>
-	<string>NSFileProtectionComplete</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>activitycontinuation:duckduckgo.com</string>

--- a/DuckDuckGo/DuckDuckGo.entitlements
+++ b/DuckDuckGo/DuckDuckGo.entitlements
@@ -4,5 +4,12 @@
 <dict>
 	<key>DataProtectionClass</key>
 	<string>NSFileProtectionComplete</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>activitycontinuation:duckduckgo.com</string>
+		<string>applinks:duckduckgo.com</string>
+		<string>applinks:infinitekind.com</string>
+		<string>activitycontinuation:infinitekind.com</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR wraps a lot of smaller changes and improvements related to:
- header bar collapsing (making it work, and making it smoother)
- supporting universal links (required server-side file and provisioning updates)
- fix to breakage of the mosaic story view layout under the recent-stories tab
- fix the crash when selecting the send-feedback email link if no email account has been setup
