### PR TITLE
(Closes #160) Adds a new button in settings that allows the user to clear both the local storage and the cookies.

### DIFF
--- a/DuckDuckGo.xcodeproj/project.pbxproj
+++ b/DuckDuckGo.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 		C1A97EE6176BD3560099EDA1 /* btn-bg_bang_example_query@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = C1A97EE4176BD3560099EDA1 /* btn-bg_bang_example_query@2x.png */; };
 		C1A97EE8176BD7AB0099EDA1 /* btn-bg_bang-default.png in Resources */ = {isa = PBXBuildFile; fileRef = C1A97EE7176BD7AB0099EDA1 /* btn-bg_bang-default.png */; };
 		C1EA87BE179EF07500A6A2A9 /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1EA87BD179EF07500A6A2A9 /* OpenGLES.framework */; };
+		D3EB24D21D92D90A0080900C /* DDGLocalStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = D3EB24D11D92D90A0080900C /* DDGLocalStorage.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1033,6 +1034,8 @@
 		C1A97EE4176BD3560099EDA1 /* btn-bg_bang_example_query@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "btn-bg_bang_example_query@2x.png"; sourceTree = "<group>"; };
 		C1A97EE7176BD7AB0099EDA1 /* btn-bg_bang-default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "btn-bg_bang-default.png"; sourceTree = "<group>"; };
 		C1EA87BD179EF07500A6A2A9 /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
+		D3EB24D01D92D90A0080900C /* DDGLocalStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDGLocalStorage.h; sourceTree = "<group>"; };
+		D3EB24D11D92D90A0080900C /* DDGLocalStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDGLocalStorage.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1770,6 +1773,7 @@
 		83F32262149290EF00A61BC5 /* DuckDuckGo */ = {
 			isa = PBXGroup;
 			children = (
+				D3EB24CF1D92D8F50080900C /* Local Storage */,
 				4C6AC43514DDA95500A1ACA1 /* 3rd Party */,
 				5B7C3BD9170B092D00B9E009 /* App */,
 				5B7C3BDA170B093300B9E009 /* Main Menu */,
@@ -1837,6 +1841,15 @@
 				84E722F41B90907B00CA0198 /* DDGSegmentedControl.m */,
 			);
 			name = "Custom Views";
+			sourceTree = "<group>";
+		};
+		D3EB24CF1D92D8F50080900C /* Local Storage */ = {
+			isa = PBXGroup;
+			children = (
+				D3EB24D01D92D90A0080900C /* DDGLocalStorage.h */,
+				D3EB24D11D92D90A0080900C /* DDGLocalStorage.m */,
+			);
+			name = "Local Storage";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2201,6 +2214,7 @@
 				7B09EDEB18E45F1D0042BB27 /* DDGMenuItemCell.m in Sources */,
 				5BA321BC16C904BA0066BCB0 /* AFHTTPClient.m in Sources */,
 				846D6B9A1BA4BE7A00EB16BC /* DDGChooseHomeViewController.m in Sources */,
+				D3EB24D21D92D90A0080900C /* DDGLocalStorage.m in Sources */,
 				5BA321BD16C904BA0066BCB0 /* AFHTTPRequestOperation.m in Sources */,
 				5BA321BE16C904BA0066BCB0 /* AFImageRequestOperation.m in Sources */,
 				8410AD551BB7353500CC83DB /* DDGImageActivityItemProvider.m in Sources */,

--- a/DuckDuckGo/DDGLocalStorage.h
+++ b/DuckDuckGo/DDGLocalStorage.h
@@ -1,0 +1,16 @@
+//
+//  DDGLocalStorage.h
+//  DuckDuckGo
+//
+//  Created by Ioannis Kokkinidis on 16/09/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface DDGLocalStorage : NSObject
+
++(instancetype)sharedInstance;  // returns a reference to this singleton
+-(void) deleteTemporaryData;    // clears all temporary local storage data (that is cookies and .localStorage files)
+
+@end

--- a/DuckDuckGo/DDGLocalStorage.m
+++ b/DuckDuckGo/DDGLocalStorage.m
@@ -1,0 +1,66 @@
+//
+//  DDGLocalStorage.m
+//  DuckDuckGo
+//
+//  Created by Ioannis Kokkinidis on 16/09/16.
+//
+//
+
+#import "DDGLocalStorage.h"
+
+#define LOCAL_STORAGE_PATH "WebKit/com.duckduckgo.mobile.ios/WebsiteData/LocalStorage"
+
+@implementation DDGLocalStorage
+
+
+
+
+#pragma mark - Initialization methods
+
++(instancetype)sharedInstance
+{
+    static dispatch_once_t pred;
+    static id sharedInstance = nil;
+    dispatch_once(&pred, ^{
+        sharedInstance = [[self alloc] initPrivate];    //we call our own init
+    });
+    return sharedInstance;
+}
+
+- (instancetype)init {  //any calls to this init should result in an error.
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Use [DDGLocalStorage sharedInstance] to get a ref to this (shared) object." userInfo:nil];
+}
+
+- (instancetype)initPrivate {   //this will be our init from now on
+    return [super init];
+}
+
+
+
+
+#pragma mark - Clearing storage data
+
+-(void) clearCookies{
+    NSHTTPCookie *cookie;
+    NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+    for (cookie in [storage cookies]) { //for each cookie
+        [storage deleteCookie:cookie];  //delete
+    }
+}
+
+-(void) clearLocalStorage {
+    NSString *path = [[NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) lastObject] stringByAppendingPathComponent:@LOCAL_STORAGE_PATH];
+    NSArray *array = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:path error:nil];
+    for (NSString *string in array) {   //for each file in our local storage dir
+        if ([[string pathExtension] isEqualToString:@"localstorage"]){  //if the file is of type .localstorage
+            [[NSFileManager defaultManager] removeItemAtPath:[path stringByAppendingPathComponent:string] error:nil];   //go ahead and delete it
+        }
+    }
+}
+
+-(void) deleteTemporaryData {
+    [self clearCookies];    // first, remove the cookies.
+    [self clearLocalStorage];   //then delete all the cache files
+}
+
+@end

--- a/DuckDuckGo/DDGSettingsViewController.h
+++ b/DuckDuckGo/DDGSettingsViewController.h
@@ -8,6 +8,7 @@
 
 #import "DDGFormViewController.h"
 #import <MessageUI/MessageUI.h>
+#import "DDGLocalStorage.h"
 
 extern NSString * const DDGSettingRecordHistory;
 extern NSString * const DDGSettingQuackOnRefresh;


### PR DESCRIPTION
This pull request solves this issue https://github.com/duckduckgo/ios/issues/160.

Up until this patch the user was not able to clear the local storage and cookies gathered while browsing. This was a problem because:
1. His privacy was not respected.
2. His disk space usage was strictly going upwards, as the local storage files were not stored on the cache dir so iOS had no say about deleting those files.
