### PR TITLE
Add media and location permissions

### DIFF
--- a/DuckDuckGo/DuckDuckGo-Info.plist
+++ b/DuckDuckGo/DuckDuckGo-Info.plist
@@ -100,5 +100,13 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSCameraUsageDescription</key>
+	<string>Allows you to upload photographs and videos</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Allows you to upload photographs and videos</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Allows you to share your location</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Allows you to share recordings</string>
 </dict>
 </plist>


### PR DESCRIPTION
Reviewer: Caine
Asana: https://app.asana.com/0/19626896268257/341836252934880

Allows users to share their location and upload photos and videos. Without this permission basic social media activities such as sharing a photo to facebook crashes
Identical to PR https://github.com/duckduckgo/iOS/pull/28 in the new app

**Steps to test this PR**:
Open facebook and share a photo, video or location. Prior to PR this would lead to a crash, with this PR applied it works.


###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)