### PR TITLE
Load links with a blank target in app not in safari

### DIFF
--- a/DuckDuckGo/DDGWebKitWebViewController.m
+++ b/DuckDuckGo/DDGWebKitWebViewController.m
@@ -262,18 +262,7 @@
         UIApplication* app = UIApplication.sharedApplication;
         NSURL* url = navigationAction.request.URL;
         
-        if (!navigationAction.targetFrame) {
-            if ([app canOpenURL:url]) {
-                [app openURL:url];
-                decisionHandler(WKNavigationActionPolicyCancel);
-                return;
-            }
-        }
         NSString* scheme = url.scheme.lowercaseString;
-        if([scheme isEqualToString:@"tel"]) { // if it's a tel: URL, then replace it with "telprompt:" to avoid initiating a call someone without confirmation!
-            scheme = @"telprompt";
-            url = [NSURL URLWithString:[url.absoluteString stringByReplacingCharactersInRange:NSMakeRange(0, 3) withString:scheme]];
-        }
         if ([scheme isEqualToString:@"mailto"]) {
             // user is interested in mailing so use the internal mail API
             [self performSelector:@selector(internalMailAction:) withObject:navigationAction.request.URL afterDelay:0.05];
@@ -288,6 +277,11 @@
                 return;
             }
         }
+        if (!navigationAction.targetFrame) {
+            [self loadQueryOrURL: url.absoluteString];
+            decisionHandler(WKNavigationActionPolicyCancel);
+            return;
+        } 
     }
     [self updateBarWithRequest:[NSURLRequest requestWithURL:webView.URL]];
     decisionHandler(WKNavigationActionPolicyAllow);


### PR DESCRIPTION
Reviewer: Caine
Asana: https://app.asana.com/0/19626896268257/341836252934879

**Description**:
Load links with a blank target in app, not in safari

**Steps to test this PR**:
Visit http://verk.space/ and tap on a link. This will currently open in Safari. After this PR is applied it will open in our app

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR DRI Checklist:
- [x] Get advice or leverage existing code
- [x] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [x] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications (Database connections, Grafana stats, CPU)